### PR TITLE
Set 'English' as the default method/property value

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
+++ b/appinventor/appengine/src/com/google/appinventor/client/TranslationComponentProperty.java
@@ -20,6 +20,13 @@ public class TranslationComponentProperty {
   }
 
   public static String getName(String key) {
+    //This is the short term solution.
+    //TODO: 
+    //We should throw an exception here if there is no matched in the map.
+    //We should manually add the non-existing method/property names to ode.java.
+    if (!myMap.containsKey(key)) {
+      return key;
+    }
     return myMap.get(key);
   }
 


### PR DESCRIPTION
This hot fix sets the default method/property names to English if there is no translation available. This is the short term solution and we will add the translation strings along the way.