### PR TITLE
use configured callback url for non-production servers

### DIFF
--- a/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
+++ b/appinventor/appengine/src/com/google/appinventor/server/project/youngandroid/YoungAndroidProjectService.java
@@ -1227,7 +1227,8 @@ public final class YoungAndroidProjectService extends CommonProjectService {
   private String getBuildServerUrlStr(String userName, String userId,
     long projectId, boolean secondBuildserver, String fileName)
       throws UnsupportedEncodingException, EncryptionException {
-    return "http://" + (secondBuildserver ? buildServerHost2.get() : buildServerHost.get()) +
+		  
+    String url = "http://" + (secondBuildserver ? buildServerHost2.get() : buildServerHost.get()) +
       "/buildserver/build-all-from-zip-async"
       + "?uname=" + URLEncoder.encode(userName, "UTF-8")
       + (sendGitVersion.get()
@@ -1240,6 +1241,9 @@ public final class YoungAndroidProjectService extends CommonProjectService {
         + Security.encryptUserAndProjectId(userId, projectId)
         + "/" + fileName,
         "UTF-8");
+		
+	LOG.info("Build server URL: " + url);
+	return url;
   }
 
   private String getCurrentHost() {
@@ -1252,8 +1256,10 @@ public final class YoungAndroidProjectService extends CommonProjectService {
         return appengineHost.get();
       }
     } else {
-      // TODO(user): Figure out how to make this more generic
-      return "localhost:8888";
+      if (StringUtils.isNullOrEmpty(appengineHost.get()))
+	    return "localhost:8888";
+	  else
+	    return appengineHost.get();
     }
   }
 


### PR DESCRIPTION
`com.google.appinventor.server.project.youngandroid.YoungAndroidProjectService` was only using the `appengine.host` URL when running on a production server. 